### PR TITLE
Fix issue with virtual actionbar on Android

### DIFF
--- a/display.js
+++ b/display.js
@@ -7,7 +7,7 @@ import {
 } from 'react-native';
 
 import * as Animatable from 'react-native-animatable';
-const screen = Dimensions.get('window');
+const screen = Dimensions.get('screen');
 const WIDTH = screen.width;
 const HEIGHT = screen.height;
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@the-bubbles-company/react-native-display",
+  "version": "1.0.9",
+  "main": "display.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "react-native-animatable": "^1.1.0"
+  }
+}


### PR DESCRIPTION
When using new devices such as the Galaxy S8, the call to `Dimensions.get('window')` doesn't return the real height due to Virtual Buttons, see https://github.com/facebook/react-native/issues/14887.